### PR TITLE
Pacer percent fix

### DIFF
--- a/app/project/pacer/page.tsx
+++ b/app/project/pacer/page.tsx
@@ -152,7 +152,9 @@ export default function PacerPage() {
         }
       }
       
-      const totalPages = end - start + 1;
+      // For discrete units (pages, locations, units), add 1 to include both start and end
+      // For continuous units (percent), don't add 1
+      const totalPages = measurement === "percent" ? end - start : end - start + 1;
       const mins = parseInt(minutes);
       calculatedPaceValue = totalPages / mins;
       calculatedEnd = end;
@@ -161,13 +163,15 @@ export default function PacerPage() {
       
       // Validate percent values
       if (measurement === "percent") {
-        if (paceValue < 0 || paceValue > 100) {
-          alert("Pace percent must be between 0 and 100");
-          return;
-        }
+        // Pace represents percent per minute, so it can be > 100 if duration is short enough
+        // Only validate that the calculated end doesn't exceed 100%
         const calculatedEndValue = start + paceValue * parseInt(minutes);
         if (calculatedEndValue > 100) {
           alert("The calculated ending percent would exceed 100. Please adjust your pace or duration.");
+          return;
+        }
+        if (paceValue < 0) {
+          alert("Pace must be greater than or equal to 0");
           return;
         }
       }
@@ -445,7 +449,6 @@ export default function PacerPage() {
                   placeholder={DEFAULT_PACE.toString()}
                   step="0.1"
                   min={measurement === "percent" ? "0" : undefined}
-                  max={measurement === "percent" ? "100" : undefined}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                   required
                 />

--- a/app/project/pacer/page.tsx
+++ b/app/project/pacer/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
+import Link from "next/link";
 
 type Mode = "CLASSIC" | "PACE";
 
 const DEFAULT_READ = "";
 const DEFAULT_MEASUREMENT = "page";
-const DEFAULT_START = "13";
+const DEFAULT_START = "1";
 const DEFAULT_MODE: Mode = "CLASSIC";
-const DEFAULT_PACE = 1.5;
+const DEFAULT_PACE = 1;
 
 export default function PacerPage() {
   const [book, setBook] = useState("");
@@ -30,6 +31,11 @@ export default function PacerPage() {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const displayIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
+
+  // Helper function to format measurement unit for display in active reading mode
+  const getDisplayUnit = () => {
+    return measurement === "percent" ? "%" : measurement;
+  };
 
   // Load cached values from localStorage on mount
   useEffect(() => {
@@ -119,17 +125,53 @@ export default function PacerPage() {
     e.preventDefault();
 
     const start = parseFloat(pageStart);
+    
+    // Validate percent values
+    if (measurement === "percent") {
+      if (start < 0 || start > 100) {
+        alert("Starting percent must be between 0 and 100");
+        return;
+      }
+    }
+    
     let calculatedPaceValue = 0;
     let calculatedEnd = 0;
 
     if (mode === "CLASSIC") {
       const end = parseFloat(pageEnd);
+      
+      // Validate percent values
+      if (measurement === "percent") {
+        if (end < 0 || end > 100) {
+          alert("Ending percent must be between 0 and 100");
+          return;
+        }
+        if (end < start) {
+          alert("Ending percent must be greater than or equal to starting percent");
+          return;
+        }
+      }
+      
       const totalPages = end - start + 1;
       const mins = parseInt(minutes);
       calculatedPaceValue = totalPages / mins;
       calculatedEnd = end;
     } else if (mode === "PACE") {
       const paceValue = parseFloat(pace);
+      
+      // Validate percent values
+      if (measurement === "percent") {
+        if (paceValue < 0 || paceValue > 100) {
+          alert("Pace percent must be between 0 and 100");
+          return;
+        }
+        const calculatedEndValue = start + paceValue * parseInt(minutes);
+        if (calculatedEndValue > 100) {
+          alert("The calculated ending percent would exceed 100. Please adjust your pace or duration.");
+          return;
+        }
+      }
+      
       const mins = parseInt(minutes);
       calculatedPaceValue = paceValue;
       calculatedEnd = start + paceValue * mins;
@@ -181,8 +223,22 @@ export default function PacerPage() {
 
   const handleRestart = () => {
     handleReset();
-    // Restart the form
-    window.location.reload();
+    // Reset form to cached/default values without reloading the page (works offline)
+    const cachedRead = localStorage.getItem("pacer_read") || DEFAULT_READ;
+    const cachedMeasurement = localStorage.getItem("pacer_measurement") || DEFAULT_MEASUREMENT;
+    const cachedStart = localStorage.getItem("pacer_start") || DEFAULT_START;
+    const cachedMode = (localStorage.getItem("pacer_mode") || DEFAULT_MODE) as Mode;
+    const cachedPace = localStorage.getItem("pacer_pace") || DEFAULT_PACE.toString();
+
+    setBook(cachedRead);
+    setMeasurement(cachedMeasurement);
+    setPageStart(cachedStart);
+    setMode(cachedMode);
+    setPace(cachedPace);
+    setPageEnd("");
+    setMinutes("");
+    setCalculatedPace(0);
+    setCalculatedPageEnd(0);
   };
 
   if (isRunning || isComplete) {
@@ -193,10 +249,10 @@ export default function PacerPage() {
           
           <div className="mb-8">
             <p className="text-xl mb-2">
-              {pageStart} - {Math.round(calculatedPageEnd)} {measurement}s
+              {measurement === "percent" ? `${pageStart}% - ${Math.round(calculatedPageEnd)}%` : `${pageStart} - ${Math.round(calculatedPageEnd)} ${getDisplayUnit()}s`}
             </p>
             <p className="text-2xl font-bold mb-4">
-              Now reading {measurement} {Math.round(currentLocation)}
+              {measurement === "percent" ? `Now reading ${Math.round(currentLocation)}%` : `Now reading ${getDisplayUnit()} ${Math.round(currentLocation)}`}
             </p>
             <p className="text-lg text-gray-600 dark:text-gray-400">
               {currentMinute}:{currentSeconds.toString().padStart(2, "0")} / {minutes}:00
@@ -219,10 +275,12 @@ export default function PacerPage() {
               <div className="bg-green-100 dark:bg-green-900 p-4 rounded-lg mb-4">
                 <p className="text-lg font-semibold mb-2">Reading Complete!</p>
                 <p>
-                  Read {book} from {measurement} {pageStart} to {measurement} {Math.round(calculatedPageEnd)} in {minutes} minutes
+                  {measurement === "percent" 
+                    ? `Read ${book} from ${pageStart}% to ${Math.round(calculatedPageEnd)}% in ${minutes} minutes`
+                    : `Read ${book} from ${getDisplayUnit()} ${pageStart} to ${getDisplayUnit()} ${Math.round(calculatedPageEnd)} in ${minutes} minutes`}
                 </p>
                 <p className="mt-2">
-                  Your pace was {Math.round(calculatedPace)} {measurement}s per minute
+                  Your pace was {Math.round(calculatedPace)}{measurement === "percent" ? "%" : ` ${getDisplayUnit()}s`} per minute
                 </p>
               </div>
               <div className="space-x-4">
@@ -280,26 +338,42 @@ export default function PacerPage() {
             >
               <option value="page">page</option>
               <option value="location">location</option>
+              <option value="percent">percent (%)</option>
               <option value="unit">unit</option>
             </select>
           </div>
 
           <div>
-            <label htmlFor="mode" className="block text-sm font-medium mb-2">
+            <label className="block text-sm font-medium mb-2">
               Select mode
             </label>
-            <select
-              id="mode"
-              value={mode}
-              onChange={(e) => setMode(e.target.value as Mode)}
-              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-            >
-              <option value="CLASSIC">CLASSIC</option>
-              <option value="PACE">PACE</option>
-            </select>
+            <div className="inline-flex rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 p-1.5">
+              <button
+                type="button"
+                onClick={() => setMode("CLASSIC")}
+                className={`px-6 py-3 rounded-md text-base font-semibold transition-colors ${
+                  mode === "CLASSIC"
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                }`}
+              >
+                CLASSIC
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode("PACE")}
+                className={`px-6 py-3 rounded-md text-base font-semibold transition-colors ${
+                  mode === "PACE"
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                }`}
+              >
+                PACE
+              </button>
+            </div>
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
               {mode === "CLASSIC"
-                ? `Enter starting ${measurement || "unit"}, ending ${measurement || "unit"}, and how long you want to read. The pace will be calculated`
+                ? `Enter starting ${measurement || "unit"}, ending ${measurement || "unit"}, and how long you want to read. The pace will be provided for you`
                 : "Enter a pace and read for a set amount of time"}
             </p>
           </div>
@@ -315,6 +389,8 @@ export default function PacerPage() {
               onChange={(e) => setPageStart(e.target.value)}
               placeholder={DEFAULT_START}
               step="0.01"
+              min={measurement === "percent" ? "0" : undefined}
+              max={measurement === "percent" ? "100" : undefined}
               className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
               required
             />
@@ -332,6 +408,8 @@ export default function PacerPage() {
                   value={pageEnd}
                   onChange={(e) => setPageEnd(e.target.value)}
                   step="0.01"
+                  min={measurement === "percent" ? "0" : undefined}
+                  max={measurement === "percent" ? "100" : undefined}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                   required
                 />
@@ -366,6 +444,8 @@ export default function PacerPage() {
                   onChange={(e) => setPace(e.target.value)}
                   placeholder={DEFAULT_PACE.toString()}
                   step="0.1"
+                  min={measurement === "percent" ? "0" : undefined}
+                  max={measurement === "percent" ? "100" : undefined}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                   required
                 />
@@ -411,6 +491,12 @@ export default function PacerPage() {
             Start Reading
           </button>
         </form>
+
+        <div style={{ marginTop: "2rem", textAlign: "center" }}>
+          <Link href="/" className="text-blue-600 dark:text-blue-400 underline">
+            Back to home
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/app/software/page.tsx
+++ b/app/software/page.tsx
@@ -56,7 +56,7 @@ export default function SoftwarePage() {
       </div>
 
       <div style={{ marginTop: "2rem", maxWidth: 500 }}>
-        <h2 style={{ fontSize: "1.3rem" }}>My Development</h2>
+        <h2 style={{ fontSize: "1.3rem" }}>My Software Development</h2>
         <p style={{ fontSize: "1.1rem", marginBottom: "2rem" }}>
           I'm a software developer by trade. The first language I learned was Python, and Python is still the language I use the most and recommend for beginners and experts alike. I also have professional experience with C#/.NET, Java, and Bash. You can read more about my experience on my <Link href="https://www.linkedin.com/in/brendan-finan-77a09ab3/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 underline">LinkedIn</Link>.
         </p>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds percent-based pacing to the Reading Pacer with validation and correct calculations, updates UI (mode toggle, display, back link), improves restart behavior, and tweaks a heading on the software page.
> 
> - **Pacer (`app/project/pacer/page.tsx`)**
>   - **New measurement option**: Add `percent` unit with input constraints, validation, and continuous-range calculations (no +1); cap PACE-mode end at 100%.
>   - **Display/UX**:
>     - Show `%` correctly in session/status and completion summaries using `getDisplayUnit()`.
>     - Replace mode `<select>` with a two-button toggle (CLASSIC/PACE) and adjust helper text.
>     - Add "Back to home" link at the bottom.
>   - **Form/behavior**:
>     - Set defaults to `DEFAULT_START = "1"`, `DEFAULT_PACE = 1`.
>     - Add `min/max` for percent inputs and non-negative pace for percent.
>     - Improve restart to reset from cached/defaults without page reload; keep caching of recent values.
>   - **Calculation**: Compute pace/end correctly for percent vs discrete units and update live location accordingly.
> - **Software page (`app/software/page.tsx`)**
>   - Rename section header to "My Software Development".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47807851f020dd9c205b704b7408534dfb49b24d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->