### PR TITLE
Tokyo URL redirect

### DIFF
--- a/app/project/pacer/page.tsx
+++ b/app/project/pacer/page.tsx
@@ -11,6 +11,10 @@ const DEFAULT_START = "1";
 const DEFAULT_MODE: Mode = "CLASSIC";
 const DEFAULT_PACE = 1;
 
+type WindowWithWebkitAudioContext = Window & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
 export default function PacerPage() {
   const [book, setBook] = useState("");
   const [measurement, setMeasurement] = useState("");
@@ -56,7 +60,11 @@ export default function PacerPage() {
   const beep = () => {
     try {
       if (!audioContextRef.current) {
-        audioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)();
+        const AudioContextCtor =
+          window.AudioContext ||
+          (window as WindowWithWebkitAudioContext).webkitAudioContext;
+        if (!AudioContextCtor) return;
+        audioContextRef.current = new AudioContextCtor();
       }
       const ctx = audioContextRef.current;
       const oscillator = ctx.createOscillator();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,15 +2,17 @@
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
-import next from "eslint-config-next";
+import nextPlugin from "@next/eslint-plugin-next";
+import reactPlugin from "eslint-plugin-react";
 
 export default [
   js.configs.recommended,
-  ...next(),
+  nextPlugin.flatConfig.coreWebVitals,
+  reactPlugin.configs.flat.recommended,
   ...tseslint.configs.recommended,
   {
     files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    languageOptions: { globals: globals.browser },
+    languageOptions: { globals: { ...globals.browser, ...globals.node } },
     rules: {
       "react/no-unescaped-entities": "off",
       "react/react-in-jsx-scope": "off"

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,16 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // optional; you can even omit this entirely
   pageExtensions: ["js", "jsx", "ts", "tsx"],
+  async redirects() {
+    return [
+      {
+        source: "/tokyo/:path*",
+        destination:
+          "https://docs.google.com/document/d/19QiG39nPI3nltA4SWrewXhPVZm5mbPobMRdxv24uoxs",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Implement a Next.js redirect for `/tokyo` to a Google Doc, including ESLint configuration updates for a clean build.

---
<a href="https://cursor.com/background-agent?bcId=bc-df65b69d-e55e-45e6-bb64-f88ccf3ebd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df65b69d-e55e-45e6-bb64-f88ccf3ebd58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

